### PR TITLE
double the efficiency of the GW in multy-component systems

### DIFF
--- a/ESAnalysis/init_dos.py
+++ b/ESAnalysis/init_dos.py
@@ -114,9 +114,13 @@ def get_IPEA_settings(wano, cpu_per_node=1, tot_nodes = 1):
 
     eval_engine = cfg["DFTEngine"]["user"][f"{GW_engine} Evalstep"]
     eval_engine["functional"] = GW_func
-    eval_engine["threads"] = cpu_per_node - 1
     mem_scale = {"PySCF": 0.85, "Turbomole": 0.75}
-    eval_engine["memory"] = int(mem_per_cpu * (cpu_per_node-1) * mem_scale[GW_engine])
+    if core_mode == "Number of Molecules of each Type":
+        # assumes two molecule types. Determining exact amount of moltype does not make sense: we does not know the min. memory required for GW of a given molecule.
+        eval_engine["threads"] = cpu_per_node//2 - 1
+    else:
+        eval_engine["threads"] = cpu_per_node - 1
+    eval_engine["memory"] = int(mem_per_cpu * eval_engine["threads"] * mem_scale[GW_engine])
     cfg["SpecialSteps"]["EvalStep"]["engine"] = f"{GW_engine} Evalstep"
 
     return cfg


### PR DESCRIPTION
if user select the "meta" setting "molecule per type" when setting number of molecules for ESAnalysis, a half of the threads is _now_used for every GW simulation. Before, we used all available node's resources. The memory scales accordingly. When using >=64 cores, this means, GW gets 31 cores per GW per type. As GW does not scale starting from 8 cores or so, this will ~double the efficiency. The only risk is the memory overflow, but this will unlikely because ESAnalysis will run on at least 32 cores or more probably 64 cores.